### PR TITLE
fix(scim): move Page to QueryResource as pageFromScimPaginationRequest

### DIFF
--- a/src/Looplex.Foundation/Entities/Service.cs
+++ b/src/Looplex.Foundation/Entities/Service.cs
@@ -30,14 +30,4 @@ public abstract class Service : Actor
   }
 
   #endregion
-
-  #region Helpers
-
-  protected static int Page(int startIndex, int count)
-  {
-    var page = (int)Math.Ceiling((double)startIndex / count);
-    return page;
-  }
-
-  #endregion
 }

--- a/src/Looplex.Foundation/OAuth2/Entities/ClientServices.cs
+++ b/src/Looplex.Foundation/OAuth2/Entities/ClientServices.cs
@@ -62,7 +62,7 @@ public class ClientServices : SCIMv2<ClientService, ClientService>
     IContext ctx = NewContext();
     _rbacService!.ThrowIfUnauthorized(_user!, GetType().Name, this.GetCallerName());
 
-    int page = Page(startIndex, count);
+    int page = QueryResource<ClientService>.pageFromScimPaginationRequest(startIndex, count);
 
     await ctx.Plugins.ExecuteAsync<IHandleInput>(ctx, cancellationToken);
 

--- a/src/Looplex.Foundation/SCIMv2/Entities/Groups.cs
+++ b/src/Looplex.Foundation/SCIMv2/Entities/Groups.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Looplex.Foundation.Helpers;
+using Looplex.Foundation.OAuth2.Entities;
 using Looplex.Foundation.Ports;
 using Looplex.Foundation.SCIMv2.Commands;
 using Looplex.Foundation.SCIMv2.Queries;
@@ -56,7 +57,7 @@ public class Groups : SCIMv2<Group, Group>
     IContext ctx = NewContext();
     _rbacService!.ThrowIfUnauthorized(_user!, GetType().Name, this.GetCallerName());
 
-    int page = Page(startIndex, count);
+    int page = QueryResource<ClientService>.pageFromScimPaginationRequest(startIndex, count);
 
     await ctx.Plugins.ExecuteAsync<IHandleInput>(ctx, cancellationToken);
 

--- a/src/Looplex.Foundation/SCIMv2/Entities/Users.cs
+++ b/src/Looplex.Foundation/SCIMv2/Entities/Users.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Looplex.Foundation.Helpers;
+using Looplex.Foundation.OAuth2.Entities;
 using Looplex.Foundation.Ports;
 using Looplex.Foundation.SCIMv2.Commands;
 using Looplex.Foundation.SCIMv2.Queries;
@@ -55,7 +56,7 @@ public class Users : SCIMv2<User, User>
     IContext ctx = NewContext();
     _rbacService!.ThrowIfUnauthorized(_user!, GetType().Name, this.GetCallerName());
 
-    int page = Page(startIndex, count);
+    int page = QueryResource<ClientService>.pageFromScimPaginationRequest(startIndex, count);
 
     await ctx.Plugins.ExecuteAsync<IHandleInput>(ctx, cancellationToken);
 

--- a/src/Looplex.Foundation/SCIMv2/Queries/QueryResource.cs
+++ b/src/Looplex.Foundation/SCIMv2/Queries/QueryResource.cs
@@ -27,4 +27,8 @@ public class QueryResource<T> : IRequest<(IList<T>, int)>
     SortBy = sortBy;
     SortOrder = sortOrder;
   }
+  public static int pageFromScimPaginationRequest(int startIndex, int count)
+  {
+    return (int)Math.Ceiling((double)startIndex / count);
+  }
 }


### PR DESCRIPTION
This PR moves the pagination method from Service to SCIMv2.QueryResource as "pageFromScimPaginationRequest" to align with modular boundaries and naming conventions (rfc7644).