### PR TITLE
fix(scimv2): camelCase items + preserve envelope 'Resources'

### DIFF
--- a/src/Looplex.Foundation/Serialization/ActorJsonSerializer.cs
+++ b/src/Looplex.Foundation/Serialization/ActorJsonSerializer.cs
@@ -8,6 +8,10 @@ using Newtonsoft.Json.Serialization;
 // ReSharper disable once CheckNamespace
 namespace Looplex.Foundation.Serialization.Json;
 
+/// <summary>
+/// JSON serializer helpers for Actor-derived types. Applies camelCase naming while preserving explicitly
+/// attributed names (e.g., [JsonProperty("Resources")]) and centralizes the naming policy across the app.
+/// </summary>
 public static class ActorJsonSerializer
 {
   // Reuse a single resolver to avoid per-call allocations; preserves explicitly specified names

--- a/src/Looplex.Foundation/Serialization/ActorJsonSerializer.cs
+++ b/src/Looplex.Foundation/Serialization/ActorJsonSerializer.cs
@@ -10,43 +10,10 @@ namespace Looplex.Foundation.Serialization.Json;
 
 public static class ActorJsonSerializer
 {
-  public static string Serialize<T>(this T actor) where T : Actor?
-  {
-    if (actor == null)
-      throw new ArgumentNullException(nameof(actor));
-
-    var resolver = new DefaultContractResolver
-    {
-      NamingStrategy = new CamelCaseNamingStrategy
-      {
-        ProcessDictionaryKeys = true,
-        OverrideSpecifiedNames = false // <-- preserve explicit names
-      }
-    };
-
-    JsonSerializerSettings settings = new()
-    {
-      ContractResolver = resolver,
-      Formatting = Formatting.Indented
-    };
-    string json = JsonConvert.SerializeObject(actor, actor.GetType(), settings);
-    return json;
-  }
-
-  public static T? Deserialize<T>(this string json) where T : Actor
-  {
-    return (T?)Deserialize(json, typeof(T));
-  }
-
-  public static object? Deserialize(this string json, Type type)
-  {
-    if (!typeof(Actor).IsAssignableFrom(type)) // Must inherit from Actor
-      throw new Exception($"Type {type.Name} must inherit from {nameof(Actor)}.");
-
-    if (string.IsNullOrWhiteSpace(json))
-      throw new ArgumentException("JSON string cannot be null or empty.", nameof(json));
-
-    var resolver = new DefaultContractResolver
+  // Reuse a single resolver to avoid per-call allocations; preserves explicitly specified names
+  // via [JsonProperty("...")] while applying camelCase to others.
+  private static readonly IContractResolver s_CamelCasePreserveSpecifiedResolver =
+    new DefaultContractResolver
     {
       NamingStrategy = new CamelCaseNamingStrategy
       {
@@ -55,7 +22,49 @@ public static class ActorJsonSerializer
       }
     };
 
-    JsonSerializerSettings settings = new() { ContractResolver = resolver };
-    return JsonConvert.DeserializeObject(json, type, settings);
+  // Static settings for serialization to reduce allocations and centralize the naming policy.
+  private static readonly JsonSerializerSettings s_SerializeSettings = new()
+  {
+    ContractResolver = s_CamelCasePreserveSpecifiedResolver,
+    Formatting = Formatting.Indented
+  };
+
+  // Static settings for deserialization with the same naming policy.
+  private static readonly JsonSerializerSettings s_DeserializeSettings = new()
+  {
+    ContractResolver = s_CamelCasePreserveSpecifiedResolver
+  };
+
+  /// <summary>
+  /// Serializes an Actor (or derived) using camelCase while honoring explicitly specified names.
+  /// </summary>
+  public static string Serialize<T>(this T actor) where T : Actor?
+  {
+    if (actor == null)
+      throw new ArgumentNullException(nameof(actor));
+
+    return JsonConvert.SerializeObject(actor, actor.GetType(), s_SerializeSettings);
+  }
+
+  /// <summary>
+  /// Deserializes JSON into the given Actor-derived type using the configured naming policy.
+  /// </summary>
+  public static T? Deserialize<T>(this string json) where T : Actor
+  {
+    return (T?)Deserialize(json, typeof(T));
+  }
+
+  /// <summary>
+  /// Deserializes JSON into the given Actor-derived type using the configured naming policy.
+  /// </summary>
+  public static object? Deserialize(this string json, Type type)
+  {
+    if (!typeof(Actor).IsAssignableFrom(type))
+      throw new Exception($"Type {type.Name} must inherit from {nameof(Actor)}.");
+
+    if (string.IsNullOrWhiteSpace(json))
+      throw new ArgumentException("JSON string cannot be null or empty.", nameof(json));
+
+    return JsonConvert.DeserializeObject(json, type, s_DeserializeSettings);
   }
 }

--- a/src/Looplex.Foundation/Serialization/ActorJsonSerializer.cs
+++ b/src/Looplex.Foundation/Serialization/ActorJsonSerializer.cs
@@ -15,9 +15,19 @@ public static class ActorJsonSerializer
     if (actor == null)
       throw new ArgumentNullException(nameof(actor));
 
+    var resolver = new DefaultContractResolver
+    {
+      NamingStrategy = new CamelCaseNamingStrategy
+      {
+        ProcessDictionaryKeys = true,
+        OverrideSpecifiedNames = false // <-- preserve explicit names
+      }
+    };
+
     JsonSerializerSettings settings = new()
     {
-      ContractResolver = new CamelCasePropertyNamesContractResolver(), Formatting = Formatting.Indented
+      ContractResolver = resolver,
+      Formatting = Formatting.Indented
     };
     string json = JsonConvert.SerializeObject(actor, actor.GetType(), settings);
     return json;
@@ -36,7 +46,16 @@ public static class ActorJsonSerializer
     if (string.IsNullOrWhiteSpace(json))
       throw new ArgumentException("JSON string cannot be null or empty.", nameof(json));
 
-    JsonSerializerSettings settings = new() { ContractResolver = new CamelCasePropertyNamesContractResolver() };
+    var resolver = new DefaultContractResolver
+    {
+      NamingStrategy = new CamelCaseNamingStrategy
+      {
+        ProcessDictionaryKeys = true,
+        OverrideSpecifiedNames = false
+      }
+    };
+
+    JsonSerializerSettings settings = new() { ContractResolver = resolver };
     return JsonConvert.DeserializeObject(json, type, settings);
   }
 }


### PR DESCRIPTION
fix(scimv2): enforce camelCase on item properties and preserve envelope 'Resources'

Align responses with SCIMv2 expectations:
- Force camelCase for resource items via JsonSerializer (overrideSpecifiedNames=true).
- Preserve envelope property name 'Resources' using ActorJsonSerializer with overrideSpecifiedNames=false.
- Keep top-level fields in camelCase (totalResults, startIndex, itemsPerPage).

Rationale: match casing shown in reference output and avoid PascalCase leaks from entities.
Refs: RFC 7644 §3.4.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - SCIM v2 now exposes /Users, /Groups, /Api-Keys and a Bulk operations endpoint.
- **Bug Fixes**
  - Single-item and list responses now consistently use camelCase and pretty-printed JSON for improved readability and interoperability.
- **Refactor**
  - Centralized JSON serialization to enforce camelCase while preserving explicitly named fields and dictionary key casing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->